### PR TITLE
Add flag to set a firewall mark on packets from mycelium

### DIFF
--- a/mycelium/Cargo.toml
+++ b/mycelium/Cargo.toml
@@ -49,6 +49,7 @@ tokio-openssl = "0.6.4"
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.14.1"
 tokio-tun = "0.11.4"
+nix = { version = "0.28.0", features = ["socket"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 tun = { git = "https://github.com/LeeSmet/rust-tun", features = ["async"] }

--- a/mycelium/src/lib.rs
+++ b/mycelium/src/lib.rs
@@ -64,6 +64,8 @@ pub struct Config<M> {
     /// Implementation of the `Metrics` trait, used to expose information about the system
     /// internals.
     pub metrics: M,
+    /// Mark that's set on all packets that we send on the underlying network
+    pub firewall_mark: Option<u32>,
 }
 
 /// The Node is the main structure in mycelium. It governs the entire data flow.
@@ -156,6 +158,7 @@ where
             config.peer_discovery_port.is_none(),
             config.private_network_config,
             config.metrics,
+            config.firewall_mark,
         )?;
         info!("Started peer manager");
 

--- a/mycelium/src/peer_manager.rs
+++ b/mycelium/src/peer_manager.rs
@@ -15,7 +15,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::io;
 use std::net::{IpAddr, SocketAddr, SocketAddrV6};
-#[cfg(target_family = "unix")]
+#[cfg(target_os = "linux")]
 use std::os::fd::AsFd;
 use std::pin::Pin;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/myceliumd/src/main.rs
+++ b/myceliumd/src/main.rs
@@ -183,7 +183,7 @@ pub struct NodeArguments {
     /// The path to the file with the key to use for the private network.
     ///
     /// The key is expected to be exactly 32 bytes. The key must be shared between all nodes
-    /// participating in the newtork, and is secret. If the key leaks, anyone can then join the
+    /// participating in the network, and is secret. If the key leaks, anyone can then join the
     /// network.
     #[arg(long = "network-key-file", requires = "network_name")]
     network_key_file: Option<PathBuf>,
@@ -195,6 +195,14 @@ pub struct NodeArguments {
     /// collected.
     #[arg(long = "metrics-api-address")]
     metrics_api_address: Option<SocketAddr>,
+
+    /// The firewall mark to set on the mycelium sockets.
+    ///
+    /// This allows to identify packets that contain encapsulated mycelium packets so that
+    /// different routing policies can be applied to them.
+    /// This option only has an effect on Linux.
+    #[arg(long = "firewall-mark")]
+    firewall_mark: Option<u32>,
 }
 
 #[tokio::main]
@@ -319,6 +327,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             tun_name: cli.node_args.tun_name,
             private_network_config,
             metrics: metrics.clone(),
+            firewall_mark: cli.node_args.firewall_mark,
         };
         metrics.spawn(metrics_api_addr);
         let node = Node::new(config).await?;
@@ -338,6 +347,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             tun_name: cli.node_args.tun_name,
             private_network_config,
             metrics: metrics::NoMetrics,
+            firewall_mark: cli.node_args.firewall_mark,
         };
         let node = Node::new(config).await?;
         api::Http::spawn(node, cli.node_args.api_addr)


### PR DESCRIPTION
This enables policy routing so that tunnels can be implemented on top of mycelium.
It enables what's described as "improved rule-based routing" in this article: https://www.wireguard.com/netns/

The mark is a meta attribute tracked by the linux kernel to make routing decisions, it is not represented in the actual packets on the wire and so does not have any impact on packet headers or MTU.

To see what this does, you can create the following nftables rules to count marked packets:
```sh
sudo nft add table ip6 test
sudo nft add chain ip6 test output { type filter hook output priority filter; policy accept; }
sudo nft add rule ip6 test output meta mark 254 counter
```
Then you can watch how many packets have been seen with the firewall mark set to `254`,
```sh
sudo watch "nft list table ip6 test"
```
which should show this for now:
```
table ip6 test {
        chain output {
                type filter hook output priority filter; policy accept;
                meta mark 0x000000fe counter packets 0 bytes 0
        }
}
```
(0xfe is 254 in hex).

With this configured, you can now start mycelium with `--firewall-mark 254`, and you will see the counter go up as mycelium starts sending marked packets onto the network.
So you should now see something like this:
```
table ip6 test {
        chain output {
                type filter hook output priority filter; policy accept;
                meta mark 0x000000fe counter packets 26066 bytes 5958392
        }
}
```

We need to set the mark option on all sockets used to send packets onto the underlying network, so currently I think that's the QUIC and TCP sockets used to talk to peers and the sockets used for LL discovery.
In a tunnel setup, these would then be the packets that are not routed through the tunnel, while all other traffic would be routed through the tunnel (and the tunnel sends them through mycelium).
