### PR TITLE
Change CI to just run Clippy command

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -31,13 +31,8 @@ jobs:
       run: vcpkg install openssl:x64-windows-static-md
       if: runner.os == 'Windows'
     - uses: actions/checkout@v4
-    - uses: dtolnay/rust-toolchain@stable
-      with:
-        components: clippy
-    - uses: giraffate/clippy-action@v1
-      with:
-        clippy_flags: -- -D warnings
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+    - name: Run Clippy
+      run: cargo clippy --all-features -- -Dwarnings
   check_library:
     strategy:
       matrix:


### PR DESCRIPTION
Default GitHub runners have it installed out of the box.

Fixes #245