### PR TITLE
switch logging to tracing ecosystem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1155,6 +1155,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-android",
+ "tracing-log",
  "tracing-oslog",
  "tracing-subscriber",
 ]
@@ -1208,6 +1209,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tracing",
+ "tracing-log",
  "tracing-subscriber",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -63,20 +63,17 @@ dependencies = [
 
 [[package]]
 name = "android_log-sys"
-version = "0.3.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ecc8056bf6ab9892dcd53216c83d1597487d7dacac16c8df6b877d127df9937"
+checksum = "85965b6739a430150bdd138e2374a98af0c3ee0d030b3bb7fc3bddff58d0102e"
 
 [[package]]
-name = "android_logger"
-version = "0.13.3"
+name = "ansi_term"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c494134f746c14dc653a35a4ea5aca24ac368529da5370ecf41fe0341c35772f"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
 dependencies = [
- "android_log-sys",
- "env_logger",
- "log",
- "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -154,6 +151,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -243,6 +251,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.59.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bd2a9a458e8f4304c52c43ebb0cfbd520289f8379a52e329a38afda99bf8eb8"
+dependencies = [
+ "bitflags 1.3.2",
+ "cexpr",
+ "clang-sys",
+ "clap 2.34.0",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +346,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +377,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "clang-sys"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67523a3b4be3ce1989d607a828d036249522dd9c1c8de7f4dd2dae43a37369d1"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "2.34.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags 1.3.2",
+ "strsim 0.8.0",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
 name = "clap"
 version = "4.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -355,7 +421,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim",
+ "strsim 0.11.0",
 ]
 
 [[package]]
@@ -461,19 +527,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "5.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
-dependencies = [
- "cfg-if",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,13 +547,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
+name = "either"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
+checksum = "a47c1c47d2f5964e29c61246e81db715514cd532db6b5116a25ea3c03d6780a2"
+
+[[package]]
+name = "env_logger"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a12e6657c4c97ebab115a42dcee77225f7f482cdd841cf7088c657a42e9e00e7"
 dependencies = [
+ "atty",
  "humantime",
- "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -716,6 +775,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "glob"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
 name = "h2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +813,15 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3d0e0f38255e7fa3cf31335b3a56f05febd18025f4db5ef7a0cfb4f8da651f"
@@ -757,6 +831,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "http"
@@ -881,6 +964,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "ioctl-sys"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,17 +989,6 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
-
-[[package]]
-name = "is-terminal"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bad00257d07be169d870ab665980b06cdb366d792ad690bf2e76876dc503455"
-dependencies = [
- "hermit-abi",
- "rustix",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "itoa"
@@ -929,6 +1010,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "left-right"
@@ -1034,6 +1121,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1057,12 +1150,13 @@ dependencies = [
 name = "mobile"
 version = "0.1.0"
 dependencies = [
- "android_logger",
- "log",
  "mycelium",
  "once_cell",
- "oslog",
  "tokio",
+ "tracing",
+ "tracing-android",
+ "tracing-oslog",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1079,7 +1173,6 @@ dependencies = [
  "ipnet",
  "left-right",
  "libc",
- "log",
  "netdev",
  "nix 0.28.0",
  "openssl",
@@ -1094,6 +1187,8 @@ dependencies = [
  "tokio-stream",
  "tokio-tun",
  "tokio-util",
+ "tracing",
+ "tracing-subscriber",
  "tun",
  "wintun 0.4.0",
  "x25519-dalek",
@@ -1105,15 +1200,15 @@ version = "0.5.2"
 dependencies = [
  "axum",
  "base64 0.22.1",
- "clap",
- "log",
+ "clap 4.5.4",
  "mycelium",
- "pretty_env_logger",
  "prometheus",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1237,6 +1332,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1252,7 +1357,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.4",
  "libc",
 ]
 
@@ -1326,21 +1431,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "oslog"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80d2043d1f61d77cb2f4b1f7b7b2295f40507f5f8e9d1c8bf10a1ca5f97a3969"
-dependencies = [
- "cc",
- "dashmap",
- "log",
-]
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "parking_lot"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
+dependencies = [
+ "instant",
+ "lock_api",
+ "parking_lot_core 0.8.6",
+]
 
 [[package]]
 name = "parking_lot"
@@ -1349,7 +1454,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
 dependencies = [
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.9.9",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
+dependencies = [
+ "cfg-if",
+ "instant",
+ "libc",
+ "redox_syscall 0.2.16",
+ "smallvec",
+ "winapi",
 ]
 
 [[package]]
@@ -1360,7 +1479,7 @@ checksum = "4c42a9226546d68acdd9c0a280d17ce19bfe27a46bf68784e4066115788d008e"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.4.1",
  "smallvec",
  "windows-targets 0.48.5",
 ]
@@ -1370,6 +1489,12 @@ name = "paste"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pem"
@@ -1456,16 +1581,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
-name = "pretty_env_logger"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
-dependencies = [
- "env_logger",
- "log",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,7 +1623,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "memchr",
- "parking_lot",
+ "parking_lot 0.12.1",
  "procfs",
  "thiserror",
 ]
@@ -1610,6 +1725,15 @@ dependencies = [
  "rustls-pki-types",
  "time",
  "yasna",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1890,6 +2014,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1928,6 +2058,12 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "strsim"
@@ -2003,6 +2139,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -2187,6 +2332,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-android"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12612be8f868a09c0ceae7113ff26afe79d81a24473a393cb9120ece162e86c0"
+dependencies = [
+ "android_log-sys",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2216,6 +2372,22 @@ dependencies = [
  "log",
  "once_cell",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-oslog"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9bc58223383423483e4bc056c7e7b3f77bdee924a9d33834112c69ead06dc847"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cfg-if",
+ "fnv",
+ "once_cell",
+ "parking_lot 0.11.2",
+ "tracing-core",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2287,6 +2459,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f5e5f3158ecfd4b8ff6fe086db7c8467a2dfdac97fe420f2b7c4aa97af66d6"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2330,6 +2508,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -2426,6 +2610,18 @@ checksum = "58cd2333b6e0be7a39605f0e255892fd7418a682d8da8fe042fe25128794d2ed"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -12,6 +12,7 @@ tokio = { version = "1.37.0", features = [
     "rt-multi-thread",
 ] }
 tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
+tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 once_cell = "1.19.0"
 

--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -11,11 +11,12 @@ tokio = { version = "1.37.0", features = [
     "signal",
     "rt-multi-thread",
 ] }
-log = "0.4.21"
+tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 once_cell = "1.19.0"
 
 [target.'cfg(target_os = "android")'.dependencies]
-android_logger = "0.13.3"
+tracing-android = "0.2.0"
 
 [target.'cfg(target_os = "ios")'.dependencies]
-oslog = "0.2.0"
+tracing-oslog = "0.1.2"

--- a/mobile/src/lib.rs
+++ b/mobile/src/lib.rs
@@ -11,6 +11,7 @@ use mycelium::{crypto, metrics, Config, Node};
 fn setup_logging() {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
+    tracing_log::LogTracer::init().expect("failed to setup tracing_log");
     tracing_subscriber::registry()
         .with(tracing_android::layer("mycelium").expect("failed to setup logger"))
         .init();
@@ -21,6 +22,7 @@ fn setup_logging() {
     use tracing_oslog::OsLogger;
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
+    tracing_log::LogTracer::init().expect("failed to setup tracing_log");
     tracing_subscriber::registry()
         .with(OsLogger::new("mycelium", "default"))
         .init();

--- a/mycelium/Cargo.toml
+++ b/mycelium/Cargo.toml
@@ -25,7 +25,8 @@ rand = "0.8.5"
 bytes = "1.6.0"
 x25519-dalek = { version = "2.0.1", features = ["getrandom", "static_secrets"] }
 aes-gcm = "0.10.3"
-log = { version = "0.4.21" }
+tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 faster-hex = "0.9.0"
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 left-right = "0.11.5"

--- a/mycelium/src/babel.rs
+++ b/mycelium/src/babel.rs
@@ -7,8 +7,8 @@
 use std::io;
 
 use bytes::{Buf, BufMut};
-use log::trace;
 use tokio_util::codec::{Decoder, Encoder};
+use tracing::trace;
 
 pub use self::{
     hello::Hello, ihu::Ihu, route_request::RouteRequest, seqno_request::SeqNoRequest,

--- a/mycelium/src/babel/hello.rs
+++ b/mycelium/src/babel/hello.rs
@@ -1,7 +1,7 @@
 //! The babel [Hello TLV](https://datatracker.ietf.org/doc/html/rfc8966#section-4.6.5).
 
 use bytes::{Buf, BufMut};
-use log::trace;
+use tracing::trace;
 
 use crate::sequence_number::SeqNo;
 

--- a/mycelium/src/babel/ihu.rs
+++ b/mycelium/src/babel/ihu.rs
@@ -3,7 +3,7 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bytes::{Buf, BufMut};
-use log::trace;
+use tracing::trace;
 
 use crate::metric::Metric;
 

--- a/mycelium/src/babel/route_request.rs
+++ b/mycelium/src/babel/route_request.rs
@@ -1,7 +1,7 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 use bytes::{Buf, BufMut};
-use log::trace;
+use tracing::trace;
 
 use crate::subnet::Subnet;
 

--- a/mycelium/src/babel/seqno_request.rs
+++ b/mycelium/src/babel/seqno_request.rs
@@ -4,7 +4,7 @@ use std::{
 };
 
 use bytes::{Buf, BufMut};
-use log::{debug, trace};
+use tracing::{debug, trace};
 
 use crate::{router_id::RouterId, sequence_number::SeqNo, subnet::Subnet};
 

--- a/mycelium/src/babel/update.rs
+++ b/mycelium/src/babel/update.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 use bytes::{Buf, BufMut};
-use log::trace;
+use tracing::trace;
 
 use crate::{metric::Metric, router_id::RouterId, sequence_number::SeqNo, subnet::Subnet};
 

--- a/mycelium/src/data.rs
+++ b/mycelium/src/data.rs
@@ -2,8 +2,8 @@ use std::net::{IpAddr, Ipv6Addr};
 
 use etherparse::{icmpv6::DestUnreachableCode, Icmpv6Type, PacketBuilder};
 use futures::{Sink, SinkExt, Stream, StreamExt};
-use log::{debug, error, trace, warn};
 use tokio::sync::mpsc::UnboundedReceiver;
+use tracing::{debug, error, trace, warn};
 
 use crate::{crypto::PacketBuffer, metrics::Metrics, packet::DataPacket, router::Router};
 
@@ -279,7 +279,7 @@ where
             let mut decrypted_packet = match shared_secret.decrypt(data_packet.raw_data) {
                 Ok(data) => data,
                 Err(_) => {
-                    log::debug!("Dropping data packet with invalid encrypted content");
+                    debug!("Dropping data packet with invalid encrypted content");
                     continue;
                 }
             };

--- a/mycelium/src/lib.rs
+++ b/mycelium/src/lib.rs
@@ -6,7 +6,6 @@ use crate::tun::TunConfig;
 use bytes::BytesMut;
 use data::DataPlane;
 use endpoint::Endpoint;
-use log::{error, info, warn};
 #[cfg(feature = "message")]
 use message::{
     MessageId, MessageInfo, MessagePushResponse, MessageStack, PushMessageError, ReceivedMessage,
@@ -15,6 +14,7 @@ use metrics::Metrics;
 use peer_manager::{PeerExists, PeerNotFound, PeerStats, PrivateNetworkKey};
 use routing_table::RouteEntry;
 use subnet::Subnet;
+use tracing::{error, info, warn};
 
 mod babel;
 mod connection;

--- a/mycelium/src/message.rs
+++ b/mycelium/src/message.rs
@@ -16,10 +16,10 @@ use std::{
 };
 
 use futures::{Stream, StreamExt};
-use log::{debug, error, trace, warn};
 use rand::Fill;
 use serde::{de::Visitor, Deserialize, Deserializer, Serialize};
 use tokio::sync::watch;
+use tracing::{debug, error, trace, warn};
 
 use crate::{
     crypto::{PacketBuffer, PublicKey},

--- a/mycelium/src/peer.rs
+++ b/mycelium/src/peer.rs
@@ -1,5 +1,4 @@
 use futures::{SinkExt, StreamExt};
-use log::{debug, error, info, trace};
 use std::{
     error::Error,
     io,
@@ -13,6 +12,7 @@ use tokio::{
     sync::{mpsc, Notify},
 };
 use tokio_util::codec::Framed;
+use tracing::{debug, error, info, trace};
 
 use crate::{
     connection::{self, Connection},

--- a/mycelium/src/peer_manager.rs
+++ b/mycelium/src/peer_manager.rs
@@ -6,7 +6,6 @@ use crate::router::Router;
 use crate::router_id::RouterId;
 use futures::stream::FuturesUnordered;
 use futures::{FutureExt, StreamExt};
-use log::{debug, error, info, trace, warn};
 use openssl::ssl::{Ssl, SslAcceptor, SslConnector, SslMethod};
 use quinn::crypto::rustls::QuicClientConfig;
 use quinn::{MtuDiscoveryConfig, ServerConfig, TransportConfig};
@@ -27,6 +26,7 @@ use tokio::net::TcpStream;
 use tokio::net::{TcpListener, UdpSocket};
 use tokio::task::AbortHandle;
 use tokio::time::MissedTickBehavior;
+use tracing::{debug, error, info, trace, warn};
 
 /// Magic bytes to identify a multicast UDP packet used in link local peer discovery.
 const MYCELIUM_MULTICAST_DISCOVERY_MAGIC: &[u8; 8] = b"mycelium";

--- a/mycelium/src/router.rs
+++ b/mycelium/src/router.rs
@@ -17,7 +17,6 @@ use etherparse::{
     Icmpv6Type,
 };
 use left_right::{ReadHandle, WriteHandle};
-use log::{debug, error, info, trace, warn};
 use std::{
     error::Error,
     net::IpAddr,
@@ -25,6 +24,7 @@ use std::{
     time::{Duration, Instant},
 };
 use tokio::sync::mpsc::{self, Receiver, Sender, UnboundedReceiver, UnboundedSender};
+use tracing::{debug, error, info, trace, warn};
 
 /// Time between HELLO messags, in seconds
 const HELLO_INTERVAL: u64 = 20;

--- a/mycelium/src/routing_table.rs
+++ b/mycelium/src/routing_table.rs
@@ -1,6 +1,6 @@
 use ip_network_table_deps_treebitmap::IpLookupTable;
-use log::{error, warn};
 use tokio::{sync::mpsc, task::JoinHandle};
+use tracing::{error, warn};
 
 use crate::{
     metric::Metric, peer::Peer, router_id::RouterId, sequence_number::SeqNo,

--- a/mycelium/src/source_table.rs
+++ b/mycelium/src/source_table.rs
@@ -1,8 +1,8 @@
 use core::fmt;
 use std::{collections::HashMap, time::Duration};
 
-use log::error;
 use tokio::{sync::mpsc, task::JoinHandle};
+use tracing::error;
 
 use crate::{
     babel, metric::Metric, router_id::RouterId, routing_table::RouteEntry, sequence_number::SeqNo,

--- a/mycelium/src/tun/android.rs
+++ b/mycelium/src/tun/android.rs
@@ -3,12 +3,12 @@
 use std::io::{self};
 
 use futures::{Sink, Stream};
-use log::{error, info};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     select,
     sync::mpsc,
 };
+use tracing::{error, info};
 
 use crate::crypto::PacketBuffer;
 use crate::tun::TunConfig;

--- a/mycelium/src/tun/darwin.rs
+++ b/mycelium/src/tun/darwin.rs
@@ -9,13 +9,13 @@ use std::{
 };
 
 use futures::{Sink, Stream};
-use log::{debug, error, info};
 use nix::sys::socket::SockaddrIn6;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     select,
     sync::mpsc,
 };
+use tracing::{debug, error, info};
 
 use crate::crypto::PacketBuffer;
 use crate::subnet::Subnet;

--- a/mycelium/src/tun/ios.rs
+++ b/mycelium/src/tun/ios.rs
@@ -3,12 +3,12 @@
 use std::io::{self, IoSlice};
 
 use futures::{Sink, Stream};
-use log::{error, info};
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     select,
     sync::mpsc,
 };
+use tracing::{error, info};
 
 use crate::crypto::PacketBuffer;
 use crate::tun::TunConfig;

--- a/mycelium/src/tun/linux.rs
+++ b/mycelium/src/tun/linux.rs
@@ -3,10 +3,10 @@
 use std::io;
 
 use futures::{Sink, Stream, TryStreamExt};
-use log::{error, info};
 use rtnetlink::Handle;
 use tokio::{select, sync::mpsc};
 use tokio_tun::{Tun, TunBuilder};
+use tracing::{error, info};
 
 use crate::crypto::PacketBuffer;
 use crate::subnet::Subnet;

--- a/mycelium/src/tun/windows.rs
+++ b/mycelium/src/tun/windows.rs
@@ -1,8 +1,8 @@
 use std::{io, ops::Deref, sync::Arc};
 
 use futures::{Sink, Stream};
-use log::{error, info, warn};
 use tokio::sync::mpsc;
+use tracing::{error, info, warn};
 
 use crate::tun::TunConfig;
 use crate::{crypto::PacketBuffer, subnet::Subnet};

--- a/myceliumd/Cargo.toml
+++ b/myceliumd/Cargo.toml
@@ -17,6 +17,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
 tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
+tracing-log = "0.2.0"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 mycelium = { path = "../mycelium", features = ["message"] }
 serde = { version = "1.0.202", features = ["derive"] }

--- a/myceliumd/Cargo.toml
+++ b/myceliumd/Cargo.toml
@@ -16,9 +16,9 @@ path = "src/main.rs"
 
 [dependencies]
 clap = { version = "4.5.4", features = ["derive"] }
-log = { version = "0.4.21", features = ["release_max_level_debug"] }
+tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
+tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 mycelium = { path = "../mycelium", features = ["message"] }
-pretty_env_logger = "0.5.0"
 serde = { version = "1.0.202", features = ["derive"] }
 serde_json = "1.0.117"
 tokio = { version = "1.37.0", features = [

--- a/myceliumd/src/api.rs
+++ b/myceliumd/src/api.rs
@@ -6,9 +6,9 @@ use axum::{
     routing::{delete, get},
     Json, Router,
 };
-use log::{debug, error};
 use serde::{Deserialize, Serialize};
 use tokio::sync::Mutex;
+use tracing::{debug, error};
 
 use mycelium::{
     endpoint::Endpoint,

--- a/myceliumd/src/api/message.rs
+++ b/myceliumd/src/api/message.rs
@@ -6,8 +6,8 @@ use axum::{
     routing::{get, post},
     Json, Router,
 };
-use log::debug;
 use serde::{Deserialize, Serialize};
+use tracing::debug;
 
 use mycelium::{
     crypto::PublicKey,

--- a/myceliumd/src/cli/message.rs
+++ b/myceliumd/src/cli/message.rs
@@ -10,9 +10,9 @@ use base64::{
     engine::{GeneralPurpose, GeneralPurposeConfig},
     Engine,
 };
-use log::{debug, error};
 use mycelium::{crypto::PublicKey, message::MessageId, subnet::Subnet};
 use serde::{Serialize, Serializer};
+use tracing::{debug, error};
 
 use crate::api::{MessageDestination, MessageReceiveInfo, MessageSendInfo, PushMessageResponse};
 

--- a/myceliumd/src/main.rs
+++ b/myceliumd/src/main.rs
@@ -222,6 +222,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
         tracing::Level::INFO
     };
 
+    // convert all `log` records from other crates to `tracing` `Event`s.
+    tracing_log::LogTracer::init_with_filter(if cli.silent {
+        tracing_log::log::LevelFilter::Error
+    } else if cli.debug {
+        tracing_log::log::LevelFilter::Debug
+    } else {
+        tracing_log::log::LevelFilter::Info
+    })?;
+
     tracing_subscriber::registry()
         .with(
             tracing_subscriber::fmt::Layer::new().compact().with_filter(

--- a/myceliumd/src/metrics.rs
+++ b/myceliumd/src/metrics.rs
@@ -4,12 +4,12 @@
 use std::net::SocketAddr;
 
 use axum::{routing::get, Router};
-use log::{error, info};
 use mycelium::metrics::Metrics;
 use prometheus::{
     opts, register_int_counter, register_int_counter_vec, register_int_gauge, Encoder, IntCounter,
     IntCounterVec, IntGauge, TextEncoder,
 };
+use tracing::{error, info};
 
 #[derive(Clone)]
 pub struct NoMetrics;


### PR DESCRIPTION
This switches:
 - from android_logger to tracing-android
 - from oslog to tracing-oslog
 - from log to the default tracing log infrastructure

Most of the noise in here is changing the imports from `log::{…}` to `tracing::{…}`.

In terms of log setup, for now this tries to stick with the existing behaviour:

 - myceliumd now uses `EnvFilter` and the `compact()` default formatter, instead of `prety_env_logger`. Its CLI args are kept as-is. `RUST_LOG` env var still works, too.
 - The `setup_the_logger` function in the `mobile` crate is renamed to `setup_logging`.


I didn't change any of the actual log messages yet.
In a future PR, I'd like to make more use of the `#[instrument]` macro to annoate some more fields, as well as enable OTLP (behind a feature flag).

Note I did not check building for IOS and Android for the `mobile` crate.