### PR TITLE
Mobile: expose  peer connection_state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1222,6 +1222,7 @@ version = "0.1.0"
 dependencies = [
  "mycelium",
  "once_cell",
+ "thiserror",
  "tokio",
  "tracing",
  "tracing-android",
@@ -2428,18 +2429,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d54378c645627613241d077a3a79db965db602882668f9136ac42af9ecb730ad"
+checksum = "c546c80d6be4bc6a00c0f01730c08df82eaa7a7a61f11d656526506112cc1709"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.56"
+version = "1.0.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
+checksum = "46c3384250002a6d5af4d114f2845d37b57521033f30d5c3f46c4d70e1197533"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/mobile/Cargo.toml
+++ b/mobile/Cargo.toml
@@ -6,11 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-mycelium = { path = "../mycelium", features = ["vendored-openssl"]}
-tokio = { version = "1.38.0", features = [
-    "signal",
-    "rt-multi-thread",
-] }
+mycelium = { path = "../mycelium", features = ["vendored-openssl"] }
+tokio = { version = "1.38.0", features = ["signal", "rt-multi-thread"] }
+thiserror = "1.0.61"
 tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 once_cell = "1.19.0"

--- a/mycelium/src/peer_manager.rs
+++ b/mycelium/src/peer_manager.rs
@@ -90,7 +90,7 @@ struct ConnectionTraffic {
 }
 
 /// General state about a connection to a [`Peer`].
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
 #[serde(rename_all = "camelCase")]
 pub enum ConnectionState {
     /// There is a working connection to the [`Peer`].


### PR DESCRIPTION
also add timeout to channel send/recv.

The mobile API returns `Vec<String>` instead of `Result<T, Error>` because the current rust bridge method can't support `Result<T,Error>`.

For it to be supported, we need to change the bridging method and maybe other changes on the kotlin/swift side, which is not worth to do for now.