### PR TITLE
Parallel routing table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   based on the OS. For more information see [README](/README.md#configuration)
 - Windows installer for Mycelium. The `.msi` file can be downloaded from the release
   assets.
+- Added flag to specify how many update workers should be started, which governs
+  the amount of parallelism used for processing updates.
 
 ### Changed
 
 - Increased the starting metric of a peer from 50 to 1000.
-- Reworked the internals of the routing table, which should reduce memory consumption
+- Reworked the internals of the routing table, which should reduce memory consumption.
+  Additionally, it is now possible to apply updates in parallel
 - Periodically reduce the allocated size of the seqno cache to avoid wasting some
   memory which is not currently used by the cache but still allocated.
 - Demote seqno cache warnings about duplicate seqno requests go debug lvl, as it

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,6 +651,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -805,8 +817,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1245,6 +1259,7 @@ dependencies = [
  "bytes",
  "etherparse",
  "faster-hex",
+ "flume",
  "futures",
  "ip_network_table-deps-treebitmap",
  "ipnet",
@@ -1312,6 +1327,15 @@ dependencies = [
  "prometheus",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -2319,6 +2343,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -651,18 +651,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
 
 [[package]]
-name = "flume"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,10 +805,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "190092ea657667030ac6a35e305e62fc4dd69fd98ac98631e5d3a2b1575a12b5"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1259,7 +1245,6 @@ dependencies = [
  "bytes",
  "etherparse",
  "faster-hex",
- "flume",
  "futures",
  "ip_network_table-deps-treebitmap",
  "ipnet",
@@ -1327,15 +1312,6 @@ dependencies = [
  "prometheus",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -2343,9 +2319,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -94,6 +94,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1240,7 @@ name = "mycelium"
 version = "0.5.3"
 dependencies = [
  "aes-gcm",
+ "arc-swap",
  "blake3",
  "bytes",
  "etherparse",

--- a/mobile/src/lib.rs
+++ b/mobile/src/lib.rs
@@ -100,6 +100,7 @@ pub async fn start_mycelium(peers: Vec<String>, tun_fd: i32, priv_key: Vec<u8>) 
         firewall_mark: None,
         #[cfg(any(target_os = "android", target_os = "ios"))]
         tun_fd: Some(tun_fd),
+        update_workers: 1,
     };
     let _node = match Node::new(config).await {
         Ok(node) => {

--- a/mycelium/Cargo.toml
+++ b/mycelium/Cargo.toml
@@ -46,7 +46,6 @@ netdev = "0.30.0"
 openssl = { version = "0.10.66", optional = true }
 tokio-openssl = { version = "0.6.4", optional = true }
 arc-swap = "1.7.1"
-flume = "0.11.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.14.1"

--- a/mycelium/Cargo.toml
+++ b/mycelium/Cargo.toml
@@ -45,6 +45,7 @@ rcgen = "0.13.1"
 netdev = "0.30.0"
 openssl = { version = "0.10.66", optional = true }
 tokio-openssl = { version = "0.6.4", optional = true }
+arc-swap = "1.7.1"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.14.1"

--- a/mycelium/Cargo.toml
+++ b/mycelium/Cargo.toml
@@ -46,6 +46,7 @@ netdev = "0.30.0"
 openssl = { version = "0.10.66", optional = true }
 tokio-openssl = { version = "0.6.4", optional = true }
 arc-swap = "1.7.1"
+flume = "0.11.0"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rtnetlink = "0.14.1"

--- a/mycelium/src/lib.rs
+++ b/mycelium/src/lib.rs
@@ -78,6 +78,12 @@ pub struct Config<M> {
     // the TUN's file descriptor to mycelium.
     #[cfg(any(target_os = "android", target_os = "ios"))]
     pub tun_fd: Option<i32>,
+
+    /// The maount of worker tasks spawned to process updates. Up to this amound of updates can be
+    /// processed in parallel. Because processing an update is a CPU bound task, it is pointless to
+    /// set this to a value which is higher than the amount of logical CPU cores available to the
+    /// system.
+    pub update_workers: usize,
 }
 
 /// The Node is the main structure in mycelium. It governs the entire data flow.
@@ -126,6 +132,7 @@ where
 
         // Creating a new Router instance
         let router = match router::Router::new(
+            config.update_workers,
             tun_tx,
             node_subnet,
             vec![node_subnet],

--- a/mycelium/src/lib.rs
+++ b/mycelium/src/lib.rs
@@ -37,6 +37,7 @@ mod seqno_cache;
 mod sequence_number;
 mod source_table;
 pub mod subnet;
+pub mod task;
 mod tun;
 
 /// The prefix of the global subnet used.

--- a/mycelium/src/router.rs
+++ b/mycelium/src/router.rs
@@ -88,6 +88,11 @@ impl<M> Router<M>
 where
     M: Metrics + Clone + Send + 'static,
 {
+    /// Create a new `Router`.
+    ///
+    /// # Panics
+    ///
+    /// If update_workers is not in the range of [1..255], this will panic.
     pub fn new(
         update_workers: usize,
         node_tun: UnboundedSender<DataPacket>,
@@ -97,6 +102,12 @@ where
         update_filters: Vec<Box<dyn RouteUpdateFilter + Send + Sync>>,
         metrics: M,
     ) -> Result<Self, Box<dyn Error>> {
+        // We could use a NonZeroU8 here, but for now just handle this manually as this might get
+        // changed in the future.
+        if !(1..255).contains(&update_workers) {
+            panic!("update workers must be at least 1 and at most 255");
+        }
+
         // Tx is passed onto each new peer instance. This enables peers to send control packets to the router.
         let (router_control_tx, router_control_rx) = mpsc::unbounded_channel();
         // Tx is passed onto each new peer instance. This enables peers to send data packets to the router.

--- a/mycelium/src/routing_table.rs
+++ b/mycelium/src/routing_table.rs
@@ -6,11 +6,11 @@ use std::{
 
 use arc_swap::ArcSwap;
 use ip_network_table_deps_treebitmap::IpLookupTable;
-use tokio::{sync::mpsc, task::AbortHandle};
+use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use tracing::{debug, error, trace};
 
-use crate::{crypto::SharedSecret, peer::Peer, subnet::Subnet};
+use crate::{crypto::SharedSecret, peer::Peer, subnet::Subnet, task::AbortHandle};
 
 pub use iter::RoutingTableIter;
 pub use iter_mut::RoutingTableIterMut;
@@ -126,7 +126,7 @@ impl RouteList {
                         }
                     }
                 })
-                .abort_handle(),
+                .abort_handle().into(),
             );
 
         self.list.push((abort_handle, re));
@@ -174,7 +174,7 @@ impl RouteGuard<'_> {
                         }
                     }
                 })
-                .abort_handle(),
+                .abort_handle().into(),
             );
 
         self.item.0.abort();

--- a/mycelium/src/routing_table/iter.rs
+++ b/mycelium/src/routing_table/iter.rs
@@ -4,6 +4,8 @@ use arc_swap::ArcSwap;
 
 use crate::{routing_table::RouteList, subnet::Subnet};
 
+use super::RouteListReadGuard;
+
 /// An iterator over a [`routing table`](super::RoutingTable) giving read only access to
 /// [`RouteList`]'s.
 pub struct RoutingTableIter<'a>(
@@ -20,14 +22,14 @@ impl<'a> RoutingTableIter<'a> {
 }
 
 impl<'a> Iterator for RoutingTableIter<'a> {
-    type Item = (Subnet, Arc<RouteList>);
+    type Item = (Subnet, RouteListReadGuard);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|(ip, prefix_size, rl)| {
             (
                 Subnet::new(ip.into(), prefix_size as u8)
                     .expect("Routing table contains valid subnets"),
-                rl.load_full(),
+                RouteListReadGuard { inner: rl.load() },
             )
         })
     }

--- a/mycelium/src/routing_table/iter.rs
+++ b/mycelium/src/routing_table/iter.rs
@@ -1,31 +1,33 @@
 use std::{net::Ipv6Addr, sync::Arc};
 
+use arc_swap::ArcSwap;
+
 use crate::{routing_table::RouteList, subnet::Subnet};
 
 /// An iterator over a [`routing table`](super::RoutingTable) giving read only access to
 /// [`RouteList`]'s.
 pub struct RoutingTableIter<'a>(
-    ip_network_table_deps_treebitmap::Iter<'a, Ipv6Addr, Arc<RouteList>>,
+    ip_network_table_deps_treebitmap::Iter<'a, Ipv6Addr, Arc<ArcSwap<RouteList>>>,
 );
 
 impl<'a> RoutingTableIter<'a> {
     /// Create a new `RoutingTableIter` which will iterate over all entries in a [`RoutingTable`].
     pub(super) fn new(
-        inner: ip_network_table_deps_treebitmap::Iter<'a, Ipv6Addr, Arc<RouteList>>,
+        inner: ip_network_table_deps_treebitmap::Iter<'a, Ipv6Addr, Arc<ArcSwap<RouteList>>>,
     ) -> Self {
         Self(inner)
     }
 }
 
 impl<'a> Iterator for RoutingTableIter<'a> {
-    type Item = (Subnet, &'a Arc<RouteList>);
+    type Item = (Subnet, Arc<RouteList>);
 
     fn next(&mut self) -> Option<Self::Item> {
         self.0.next().map(|(ip, prefix_size, rl)| {
             (
                 Subnet::new(ip.into(), prefix_size as u8)
                     .expect("Routing table contains valid subnets"),
-                rl,
+                rl.load_full(),
             )
         })
     }

--- a/mycelium/src/routing_table/route_entry.rs
+++ b/mycelium/src/routing_table/route_entry.rs
@@ -100,7 +100,7 @@ impl RouteEntry {
     }
 
     /// Sets the expiration time for this [`RouteEntry`].
-    pub fn set_expires(&mut self, expires: Instant) {
+    pub(super) fn set_expires(&mut self, expires: Instant) {
         self.expires = expires;
     }
 }

--- a/mycelium/src/task.rs
+++ b/mycelium/src/task.rs
@@ -1,0 +1,29 @@
+//! This module provides some task abstractions which add custom logic to the default behavior.
+
+/// A handle to a task, which is only used to abort the task. In case this handle is dropped, the
+/// task is cancelled automatically.
+pub struct AbortHandle(tokio::task::AbortHandle);
+
+impl AbortHandle {
+    /// Abort the task this `AbortHandle` is referencing. It is safe to call this method multiple
+    /// times, but only the first call is actually usefull. It is possible for the task to still
+    /// finish succesfully, even after abort is called.
+    #[inline]
+    pub fn abort(&self) {
+        self.0.abort()
+    }
+}
+
+impl Drop for AbortHandle {
+    #[inline]
+    fn drop(&mut self) {
+        self.0.abort()
+    }
+}
+
+impl From<tokio::task::AbortHandle> for AbortHandle {
+    #[inline]
+    fn from(value: tokio::task::AbortHandle) -> Self {
+        Self(value)
+    }
+}

--- a/myceliumd-private/Cargo.lock
+++ b/myceliumd-private/Cargo.lock
@@ -747,18 +747,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "flume"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -913,10 +901,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1331,7 +1317,6 @@ dependencies = [
  "bytes",
  "etherparse",
  "faster-hex",
- "flume",
  "futures",
  "ip_network_table-deps-treebitmap",
  "ipnet",
@@ -1419,15 +1404,6 @@ dependencies = [
  "tracing",
  "tracing-logfmt",
  "tracing-subscriber",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -2499,9 +2475,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "strsim"

--- a/myceliumd-private/Cargo.lock
+++ b/myceliumd-private/Cargo.lock
@@ -747,6 +747,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -901,8 +913,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1317,6 +1331,7 @@ dependencies = [
  "bytes",
  "etherparse",
  "faster-hex",
+ "flume",
  "futures",
  "ip_network_table-deps-treebitmap",
  "ipnet",
@@ -1404,6 +1419,15 @@ dependencies = [
  "tracing",
  "tracing-logfmt",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -2475,6 +2499,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "strsim"

--- a/myceliumd-private/Cargo.lock
+++ b/myceliumd-private/Cargo.lock
@@ -128,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1312,7 @@ name = "mycelium"
 version = "0.5.3"
 dependencies = [
  "aes-gcm",
+ "arc-swap",
  "blake3",
  "bytes",
  "etherparse",

--- a/myceliumd-private/src/main.rs
+++ b/myceliumd-private/src/main.rs
@@ -292,6 +292,15 @@ pub struct NodeArguments {
     /// This option only has an effect on Linux.
     #[arg(long = "firewall-mark")]
     firewall_mark: Option<u32>,
+
+    /// The amount of worker tasks to spawn to handle updates.
+    ///
+    /// By default, updates are processed on a single task only. This is sufficient for most use
+    /// cases. In case you notice that the node can't keep up with the incoming updates (typically
+    /// because you are running a public node with a lot of connections), this value can be
+    /// increased to process updates in parallel.
+    #[arg(long = "update-workers", default_value_t = 1)]
+    update_workers: usize,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -310,6 +319,7 @@ struct MyceliumConfig {
     network_name: Option<String>,
     network_key_file: Option<PathBuf>,
     firewall_mark: Option<u32>,
+    update_workers: Option<usize>,
 }
 
 #[tokio::main]
@@ -443,6 +453,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     private_network_config,
                     metrics: metrics.clone(),
                     firewall_mark: merged_config.firewall_mark,
+                    update_workers: merged_config.update_workers,
                 };
                 metrics.spawn(metrics_api_addr);
                 let node = Node::new(config).await?;
@@ -467,6 +478,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     private_network_config,
                     metrics: mycelium_metrics::NoMetrics,
                     firewall_mark: merged_config.firewall_mark,
+                    update_workers: merged_config.update_workers,
                 };
                 let node = Node::new(config).await?;
                 mycelium_api::Http::spawn(node, merged_config.api_addr)
@@ -671,6 +683,11 @@ fn merge_config(cli_args: NodeArguments, file_config: MyceliumConfig) -> NodeArg
         network_name: cli_args.network_name.or(file_config.network_name),
         network_key_file: cli_args.network_key_file.or(file_config.network_key_file),
         firewall_mark: cli_args.firewall_mark.or(file_config.firewall_mark),
+        update_workers: if cli_args.update_workers != 1 {
+            cli_args.update_workers
+        } else {
+            file_config.update_workers.unwrap_or(1)
+        },
     }
 }
 

--- a/myceliumd/Cargo.lock
+++ b/myceliumd/Cargo.lock
@@ -747,18 +747,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
-name = "flume"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
-dependencies = [
- "futures-core",
- "futures-sink",
- "nanorand",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -898,10 +886,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1316,7 +1302,6 @@ dependencies = [
  "bytes",
  "etherparse",
  "faster-hex",
- "flume",
  "futures",
  "ip_network_table-deps-treebitmap",
  "ipnet",
@@ -1405,15 +1390,6 @@ dependencies = [
  "tracing-logfmt",
  "tracing-subscriber",
  "urlencoding",
-]
-
-[[package]]
-name = "nanorand"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -2431,9 +2407,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "strsim"

--- a/myceliumd/Cargo.lock
+++ b/myceliumd/Cargo.lock
@@ -747,6 +747,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "flume"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55ac459de2512911e4b674ce33cf20befaba382d05b62b008afc1c8b57cbf181"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,8 +898,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1302,6 +1316,7 @@ dependencies = [
  "bytes",
  "etherparse",
  "faster-hex",
+ "flume",
  "futures",
  "ip_network_table-deps-treebitmap",
  "ipnet",
@@ -1390,6 +1405,15 @@ dependencies = [
  "tracing-logfmt",
  "tracing-subscriber",
  "urlencoding",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -2407,6 +2431,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "strsim"

--- a/myceliumd/Cargo.lock
+++ b/myceliumd/Cargo.lock
@@ -128,6 +128,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3d1d046238990b9cf5bcde22a3fb3584ee5cf65fb2765f454ed428c7a0063da"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "arrayref"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1297,7 @@ name = "mycelium"
 version = "0.5.3"
 dependencies = [
  "aes-gcm",
+ "arc-swap",
  "blake3",
  "bytes",
  "etherparse",


### PR DESCRIPTION
Make the routing table somewhat parallel, by wrapping the RouteList in an ArcSwap

The current implementation is tested and managed to stabilize one of the public peers which could not keep up. At 5 worker tasks, it eventually stabilizes to some 40% utilization of those. It should be noted that the current implementation is not optimal, and more work is needed for that. On top of this, the worker count still needs to be made configurable.

One thing which is currently an issue: the rcu closure could be called multiple times. Since we don't properly drop routeentries which aren't used anymore, this "leaks" tasks for cleanup. That is something which still needs addressing. Wrapping the aborthandles in a type which always calls "abort" on drop would probably be a good idea here.

Besides all that, some perfomance testiing is also still needed.

#342