### PR TITLE
bump tracing-logfmt to 0.3.5, enable ansi_logs feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1456,6 +1456,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2679,10 +2688,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-logfmt"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b8e455f6caa5212a102ec530bf86b8dc5a4c536299bffd84b238fed9119be7"
+checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
 dependencies = [
+ "nu-ansi-term 0.50.1",
  "time",
  "tracing",
  "tracing-core",
@@ -2712,7 +2722,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
  "sharded-slab",

--- a/mycelium/Cargo.toml
+++ b/mycelium/Cargo.toml
@@ -28,7 +28,7 @@ x25519-dalek = { version = "2.0.1", features = ["getrandom", "static_secrets"] }
 aes-gcm = "0.10.3"
 tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-tracing-logfmt = { version = "0.3.4" }
+tracing-logfmt = { version = "0.3.5", features = ["ansi_logs"] }
 faster-hex = "0.9.0"
 tokio-stream = { version = "0.1.15", features = ["sync"] }
 left-right = "0.11.5"

--- a/myceliumd-private/Cargo.lock
+++ b/myceliumd-private/Cargo.lock
@@ -1548,6 +1548,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2843,10 +2852,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-logfmt"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b8e455f6caa5212a102ec530bf86b8dc5a4c536299bffd84b238fed9119be7"
+checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
 dependencies = [
+ "nu-ansi-term 0.50.1",
  "time",
  "tracing",
  "tracing-core",
@@ -2860,7 +2870,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
  "sharded-slab",

--- a/myceliumd-private/Cargo.toml
+++ b/myceliumd-private/Cargo.toml
@@ -16,7 +16,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.11", features = ["derive"] }
 tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
-tracing-logfmt = "0.3.4"
+tracing-logfmt = { version = "0.3.5", features = ["ansi_logs"] }
 tracing-subscriber = { version = "0.3.18", features = [
   "env-filter",
   "nu-ansi-term",

--- a/myceliumd/Cargo.lock
+++ b/myceliumd/Cargo.lock
@@ -1534,6 +1534,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2763,10 +2772,11 @@ dependencies = [
 
 [[package]]
 name = "tracing-logfmt"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22b8e455f6caa5212a102ec530bf86b8dc5a4c536299bffd84b238fed9119be7"
+checksum = "6b1f47d22deb79c3f59fcf2a1f00f60cbdc05462bf17d1cd356c1fefa3f444bd"
 dependencies = [
+ "nu-ansi-term 0.50.1",
  "time",
  "tracing",
  "tracing-core",
@@ -2780,7 +2790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
  "matchers",
- "nu-ansi-term",
+ "nu-ansi-term 0.46.0",
  "once_cell",
  "regex",
  "sharded-slab",

--- a/myceliumd/Cargo.toml
+++ b/myceliumd/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/main.rs"
 [dependencies]
 clap = { version = "4.5.11", features = ["derive"] }
 tracing = { version = "0.1.40", features = ["release_max_level_debug"] }
-tracing-logfmt = "0.3.4"
+tracing-logfmt = { version = "0.3.5", features = ["ansi_logs"] }
 tracing-subscriber = { version = "0.3.18", features = [
   "env-filter",
   "nu-ansi-term",


### PR DESCRIPTION
This will cause to be outputted with color in case the output is a terminal, but will refrain from doing so if it's run by a service manager.

Follow-up to #316, unblocked by
https://github.com/EmbarkStudios/tracing-logfmt/pull/16