### PR TITLE
Fixed unzipping wintun in release.yaml

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,7 +104,7 @@ jobs:
         run: curl -o wintun.zip https://www.wintun.net/builds/wintun-0.14.1.zip
 
       - name: Unzip Wintun
-        run: tar -xf wintun.zip
+        run: unzip wintun.zip
 
       - name: Move .dll file to myceliumd directory
         run: move wintun\bin\amd64\wintun.dll myceliumd


### PR DESCRIPTION
Used wrong `tar -xf` command to unzip wintun.zip archive. Fixed by using `unzip` command.